### PR TITLE
Bug na taxa de perdas corrigido

### DIFF
--- a/cc/Messenger.cpp
+++ b/cc/Messenger.cpp
@@ -107,8 +107,19 @@ string Messenger::to_string(double num) {
 }
 
 double Messenger::get_battery(char id) {
+	if(!xbee) return -1;
 	string msg = xbee->send_get_answer(id,"B");
 	if(msg.empty() || msg[0] != 'B') return -1;
 	msg.erase(0,1);
 	return ((stod(msg) - 6.4)/2.0)*100; // % of battery
+}
+
+ack_count Messenger::get_ack_count(char id){
+	if(!xbee) return {-1,-1,-1};
+	else return xbee->get_ack_count(id);
+}
+
+void Messenger::reset_lost_acks() {
+	if(!xbee) return;
+	xbee->reset_lost_acks();
 }

--- a/cc/Messenger.h
+++ b/cc/Messenger.h
@@ -28,6 +28,8 @@ class Messenger {
 		void send_old_format(std::string cmd);
 		std::string to_string(double num);
 		double get_battery(char id);
+		ack_count get_ack_count(char id);
+		void reset_lost_acks();
 		void start_xbee(const std::string& port, int baud = 115200);
 		void stop_xbee();
 };

--- a/cc/Xbee.h
+++ b/cc/Xbee.h
@@ -8,15 +8,22 @@
 #include <cstring>
 #include <unordered_map>
 
-struct robot_xbee {
-	char id;
-	uint16_t addr;
-	struct xbee_con *con;
-};
-
 struct message {
 	char id;
 	std::string data;
+};
+
+struct ack_count {
+	int lost;
+	int total;
+	double lost_rate;
+};
+
+struct robot_xbee {
+	char id;
+	uint16_t addr;
+	xbee_con *con;
+	ack_count acks;
 };
 
 class Xbee {
@@ -32,6 +39,9 @@ class Xbee {
 		std::string send_get_answer(char id, const std::string &message);
 		std::vector<message> send_get_answer_all(const std::string &message);
 		std::stack<message> get_messages();
+		void update_ack(char id, int ack);
+		ack_count get_ack_count(char id);
+		void reset_lost_acks();
 		std::string get_string(xbee_pkt *pkt);
 };
 

--- a/cc/camcap.hpp
+++ b/cc/camcap.hpp
@@ -372,6 +372,7 @@ public:
         } // if !draw_info_flag
 
         updateAllPositions();
+		control.update_dropped_frames();
 
         if (interface.imageView.PID_test_flag && !interface.get_start_game_flag()) {
             control.button_PID_Test.set_active(true);
@@ -473,8 +474,7 @@ public:
                 robot_list[0].position = robot_kf_est[0];
                 robot_list[1].position = robot_kf_est[1];
                 robot_list[2].position = robot_kf_est[2];
-                std::vector<message> acks = control.messenger.sendCMDs(robot_list);
-//				control.update_dropped_frames(acks);
+                control.messenger.sendCMDs(robot_list);
             }
             boost::this_thread::sleep(boost::posix_time::milliseconds(200));
         }

--- a/cc/controlGUI.hpp
+++ b/cc/controlGUI.hpp
@@ -69,10 +69,7 @@ public:
 	Gtk::Label lastUpdate_lb;
 	Gtk::ProgressBar battery_bar[TOTAL_ROBOTS];
 		Gtk::Label dropped_frames[TOTAL_ROBOTS];
-		Gtk::Label dropped_frames_text[TOTAL_ROBOTS];
 		Gtk::Button bt_reset_ack;
-		int dropped_frames_num[TOTAL_ROBOTS] = {0};
-		int total_frames_num[TOTAL_ROBOTS] = {0};
 
 	Gtk::Frame pid_fm;
 	Gtk::VBox pid_vbox;
@@ -119,7 +116,7 @@ public:
 	
 	int get_robot_pos(char id);
     char get_robot_id(int pos);
-		void update_dropped_frames(std::vector<message> acks);
+		void update_dropped_frames();
 		void reset_lost_acks();
 };
 


### PR DESCRIPTION
-Taxa de perdas funciona corretamente, foi reativada na interface. Função é chamada pela thread principal, porque chamá-la de outra thread era a causa do bug
-Interface exibe também o numero de mensagens enviadas para cada robô
-Calculo de taxa de perdas ocorre dentro da classe Xbee, sendo atualizada com qualquer mensagem, incluindo updates de baterias e mensagens enviadas manualmente