### PR TITLE
Adição da conversão para o CIELAB na segmentação simples da Visão.

### DIFF
--- a/cc/jsonSaveManager.cpp
+++ b/cc/jsonSaveManager.cpp
@@ -139,7 +139,7 @@ void jsonSaveManager::load_camera() {
 	}
 
 	if(exists(camera_config, "offsetL")) interface->offsetL = camera_config["offsetL"];
-	if(exists(camera_config, "offsetL")) interface->offsetR = camera_config["offsetR"];
+	if(exists(camera_config, "offsetR")) interface->offsetR = camera_config["offsetR"];
 
 	if(exists(camera_config, "Camera Properties")){
 		json& properties_config = camera_config["Camera Properties"];

--- a/cc/jsonSaveManager.cpp
+++ b/cc/jsonSaveManager.cpp
@@ -48,10 +48,23 @@ void jsonSaveManager::save_camera() {
 		hsv["saturation_max"] = vision.getSaturation(i, 1);
 		hsv["value_min"] = vision.getValue(i, 0);
 		hsv["value_max"] = vision.getValue(i, 1);
-		hsv["dilate"] = vision.getDilate(i);
-		hsv["erode"] = vision.getErode(i);
-		hsv["blur"] = vision.getBlur(i);
-		hsv["amin"] = vision.getAmin(i);
+		hsv["dilate"] = vision.getDilate(vision.HSV, i);
+		hsv["erode"] = vision.getErode(vision.HSV, i);
+		hsv["blur"] = vision.getBlur(vision.HSV, i);
+		hsv["amin"] = vision.getAmin(vision.HSV, i);
+
+		json& lab = camera_config["CIELAB Calibration"][hsv_calibs[i]];
+
+		lab["L_min"] = vision.getCIE_L(i, 0);
+		lab["L_max"] = vision.getCIE_L(i, 1);
+		lab["A_min"] = vision.getCIE_A(i, 0);
+		lab["A_max"] = vision.getCIE_A(i, 1);
+		lab["B_min"] = vision.getCIE_B(i, 0);
+		lab["B_max"] = vision.getCIE_B(i, 1);
+		lab["dilate"] = vision.getDilate(vision.CIELAB, i);
+		lab["erode"] = vision.getErode(vision.CIELAB, i);
+		lab["blur"] = vision.getBlur(vision.CIELAB, i);
+		lab["amin"] = vision.getAmin(vision.CIELAB, i);
 	}
 
 	if(interface->warped) {
@@ -83,6 +96,7 @@ void jsonSaveManager::load_camera() {
 	string hsv_calibs[4] = {"Main", "Green", "Ball", "Opp."};
 	for (int i = 0; i < 4; ++i) {
 		json& hsv = camera_config["HSV Calibration"][hsv_calibs[i]];
+		json& lab = camera_config["CIELAB Calibration"][hsv_calibs[i]];
 		Vision& vision = *(interface->visionGUI.vision);
 
 		if(exists(hsv, "hue_min")) vision.setHue(i, 0, hsv["hue_min"]);
@@ -91,10 +105,21 @@ void jsonSaveManager::load_camera() {
 		if(exists(hsv, "saturation_max")) vision.setSaturation(i, 1, hsv["saturation_max"]);
 		if(exists(hsv, "value_min")) vision.setValue(i, 0, hsv["value_min"]);
 		if(exists(hsv, "value_max")) vision.setValue(i, 1, hsv["value_max"]);
-		if(exists(hsv, "dilate")) vision.setDilate(i, hsv["dilate"]);
-		if(exists(hsv, "erode")) vision.setErode(i, hsv["erode"]);
-		if(exists(hsv, "blur")) vision.setBlur(i, hsv["blur"]);
-		if(exists(hsv, "amin")) vision.setAmin(i, hsv["amin"]);
+		if(exists(hsv, "dilate")) vision.setDilate(vision.HSV, i, hsv["dilate"]);
+		if(exists(hsv, "erode")) vision.setErode(vision.HSV, i, hsv["erode"]);
+		if(exists(hsv, "blur")) vision.setBlur(vision.HSV, i, hsv["blur"]);
+		if(exists(hsv, "amin")) vision.setAmin(vision.HSV, i, hsv["amin"]);
+
+		if(exists(lab, "L_min")) vision.setCIE_L(i, 0, lab["L_min"]);
+		if(exists(lab, "L_max")) vision.setCIE_L(i, 1, lab["L_max"]);
+		if(exists(lab, "A_min")) vision.setCIE_A(i, 0, lab["A_min"]);
+		if(exists(lab, "A_max")) vision.setCIE_A(i, 1, lab["A_max"]);
+		if(exists(lab, "B_min")) vision.setCIE_B(i, 0, lab["B_min"]);
+		if(exists(lab, "B_max")) vision.setCIE_B(i, 1, lab["B_max"]);
+		if(exists(lab, "dilate")) vision.setDilate(vision.CIELAB, i, lab["dilate"]);
+		if(exists(lab, "erode")) vision.setErode(vision.CIELAB, i, lab["erode"]);
+		if(exists(lab, "blur")) vision.setBlur(vision.CIELAB, i, lab["blur"]);
+		if(exists(lab, "amin")) vision.setAmin(vision.CIELAB, i, lab["amin"]);
 	}
 
 	if(exists(camera_config, "warp_mat")){

--- a/cc/vision/vision.cpp
+++ b/cc/vision/vision.cpp
@@ -22,7 +22,8 @@ void Vision::runGMM(std::vector<cv::Mat> thresholds, std::vector<VisionROI> *win
 }
 
 void Vision::preProcessing() {
-  cv::cvtColor(in_frame,hsv_frame,cv::COLOR_RGB2HSV);
+	if (convertType == HSV) cv::cvtColor(in_frame,hsv_frame,cv::COLOR_RGB2HSV);
+	else cv::cvtColor(in_frame,hsv_frame,cv::COLOR_RGB2Lab);
 }
 
 void Vision::findTags() {
@@ -46,9 +47,9 @@ void Vision::posProcessing(int color) {
   cv::Mat erodeElement = cv::getStructuringElement( cv::MORPH_RECT,cv::Size(3,3));
   cv::Mat dilateElement = cv::getStructuringElement( cv::MORPH_RECT,cv::Size(3,3));
 
-  cv::medianBlur(threshold_frame.at(color), threshold_frame.at(color), blur[color]);
-  cv::erode(threshold_frame.at(color),threshold_frame.at(color),erodeElement,cv::Point(-1,-1),erode[color]);
-  cv::dilate(threshold_frame.at(color),threshold_frame.at(color),dilateElement,cv::Point(-1,-1),dilate[color]);
+  cv::medianBlur(threshold_frame.at(color), threshold_frame.at(color), blur[convertType][color]);
+  cv::erode(threshold_frame.at(color),threshold_frame.at(color),erodeElement,cv::Point(-1,-1),erode[convertType][color]);
+  cv::dilate(threshold_frame.at(color),threshold_frame.at(color),dilateElement,cv::Point(-1,-1),dilate[convertType][color]);
 }
 
 void Vision::searchGMMTags(std::vector<cv::Mat> thresholds) {
@@ -91,7 +92,7 @@ void Vision::searchTags(int color) {
 
   for (int i = 0; i < contours.size(); i++) {
     double area = contourArea(contours[i]);
-    if(area >= areaMin[color]) {
+    if(area >= areaMin[convertType][color]) {
       cv::Moments moment = moments((cv::Mat)contours[i]);
 
       // seta as linhas para as tags principais do pick-a-tag
@@ -421,21 +422,21 @@ void Vision::switchMainWithAdv() {
     value[ADV][i] = tmp;
   }
 
-  tmp = areaMin[MAIN];
-  areaMin[MAIN] = areaMin[ADV];
-  areaMin[ADV] = tmp;
+  tmp = areaMin[convertType][MAIN];
+  areaMin[convertType][MAIN] = areaMin[convertType][ADV];
+  areaMin[convertType][ADV] = tmp;
 
-  tmp = erode[MAIN];
-  erode[MAIN] = erode[ADV];
-  erode[ADV] = tmp;
+  tmp = erode[convertType][MAIN];
+  erode[convertType][MAIN] = erode[convertType][ADV];
+  erode[convertType][ADV] = tmp;
 
-  tmp = dilate[MAIN];
-  dilate[MAIN] = dilate[ADV];
-  dilate[ADV] = tmp;
+  tmp = dilate[convertType][MAIN];
+  dilate[convertType][MAIN] = dilate[convertType][ADV];
+  dilate[convertType][ADV] = tmp;
 
-  tmp = blur[MAIN];
-  blur[MAIN] = blur[ADV];
-  blur[ADV] = tmp;
+  tmp = blur[convertType][MAIN];
+  blur[convertType][MAIN] = blur[convertType][ADV];
+  blur[convertType][ADV] = tmp;
 }
 
 cv::Mat Vision::getSplitFrame() {
@@ -460,21 +461,38 @@ cv::Mat Vision::getSplitFrame() {
   return splitFrame;
 }
 
-void Vision::setCalibParams(int H[5][2], int S[5][2], int V[5][2], int Amin[5], int E[5], int D[5], int B[5])
+void Vision::setCalibParams(int type, int H[5][2], int S[5][2], int V[5][2], int Amin[5], int E[5], int D[5], int B[5])
 {
-  for (int i = 0; i < 5; i++)
-  {
-    areaMin[i] = Amin[i];
-    erode[i] = E[i];
-    dilate[i] = D[i];
-    blur[i] = B[i];
-    for (int j = 0; j < 2; j++)
-    {
-      hue[i][j] = H[i][j];
-      saturation[i][j] = S[i][j];
-      value[i][j] = V[i][j];
-    }
-  }
+	if (type == HSV) {
+		for (int i = 0; i < TOTAL_COLORS; i++)
+		{
+			areaMin[type][i] = Amin[i];
+			erode[type][i] = E[i];
+			dilate[type][i] = D[i];
+			blur[type][i] = B[i];
+			for (int j = 0; j < 2; j++)
+			{
+				hue[i][j] = H[i][j];
+				saturation[i][j] = S[i][j];
+				value[i][j] = V[i][j];
+			}
+		}
+	} else { // CIELAB
+		for (int i = 0; i < TOTAL_COLORS; i++)
+		{
+			areaMin[type][i] = Amin[i];
+			erode[type][i] = E[i];
+			dilate[type][i] = D[i];
+			blur[type][i] = B[i];
+			for (int j = 0; j < 2; j++)
+			{
+				cieL[i][j] = H[i][j];
+				cieA[i][j] = S[i][j];
+				cieB[i][j] = V[i][j];
+			}
+		}
+	}
+
 }
 
 void Vision::savePicture(std::string in_name) {
@@ -561,25 +579,56 @@ int Vision::getValue(int index0, int index1) {
   return value[index0][index1];
 }
 
-int Vision::getErode(int index) {
-  return erode[index];
+int Vision::getCIE_L(int index0, int index1) {
+	return cieL[index0][index1];
 }
 
-int Vision::getDilate(int index) {
-  return dilate[index];
+int Vision::getCIE_A(int index0, int index1) {
+	return cieA[index0][index1];
 }
 
-int Vision::getBlur(int index) {
-  return blur[index];
+int Vision::getCIE_B(int index0, int index1) {
+	return cieB[index0][index1];
 }
 
-int Vision::getAmin(int index) {
-  return areaMin[index];
+int Vision::getErode(int convertType, int index) {
+	return erode[convertType][index];
+}
+
+int Vision::getDilate(int convertType, int index) {
+  return dilate[convertType][index];
+}
+
+int Vision::getBlur(int convertType, int index) {
+  return blur[convertType][index];
+}
+
+int Vision::getAmin(int convertType, int index) {
+  return areaMin[convertType][index];
+}
+
+int Vision::getConvertType() {
+	return convertType;
 }
 
 void Vision::setHue(int index0, int index1, int inValue) {
   if (index0 >= 0 && index0 < TOTAL_COLORS && (index1 == 0 || index1 == 1)) hue[index0][index1] = inValue;
   else std::cout << "Vision:setHue: could not set (invalid index)" << std::endl;
+}
+
+void Vision::setCIE_L(int index0, int index1, int inValue) {
+	if (index0 >= 0 && index0 < TOTAL_COLORS && (index1 == 0 || index1 == 1)) cieL[index0][index1] = inValue;
+	else std::cout << "Vision:setCIE_L: could not set (invalid index)" << std::endl;
+}
+
+void Vision::setCIE_A(int index0, int index1, int inValue) {
+	if (index0 >= 0 && index0 < TOTAL_COLORS && (index1 == 0 || index1 == 1)) cieA[index0][index1] = inValue;
+	else std::cout << "Vision:setCIE_A: could not set (invalid index)" << std::endl;
+}
+
+void Vision::setCIE_B(int index0, int index1, int inValue) {
+	if (index0 >= 0 && index0 < TOTAL_COLORS && (index1 == 0 || index1 == 1)) cieB[index0][index1] = inValue;
+	else std::cout << "Vision:setCIE_B: could not set (invalid index)" << std::endl;
 }
 
 void Vision::setSaturation(int index0, int index1, int inValue) {
@@ -592,24 +641,29 @@ void Vision::setValue(int index0, int index1, int inValue) {
   else std::cout << "Vision:setValue: could not set (invalid index)" << std::endl;
 }
 
-void Vision::setErode(int index, int inValue) {
-  if (index >= 0 && index < TOTAL_COLORS) erode[index] = inValue;
-  else std::cout << "Vision:setErode: could not set (invalid index)" << std::endl;
+void Vision::setErode(int convertType, int index, int inValue) {
+  if (index >= 0 && index < TOTAL_COLORS && (convertType == HSV || convertType == CIELAB)) erode[convertType][index] = inValue;
+  else std::cout << "Vision:setErode: could not set (invalid index or convert type)" << std::endl;
 }
 
-void Vision::setDilate(int index, int inValue) {
-  if (index >= 0 && index < TOTAL_COLORS) dilate[index] = inValue;
-  else std::cout << "Vision:setDilate: could not set (invalid index)" << std::endl;
+void Vision::setDilate(int convertType, int index, int inValue) {
+  if (index >= 0 && index < TOTAL_COLORS && (convertType == HSV || convertType == CIELAB)) dilate[convertType][index] = inValue;
+  else std::cout << "Vision:setDilate: could not set (invalid index or convert type)" << std::endl;
 }
 
-void Vision::setBlur(int index, int inValue) {
-  if (index >= 0 && index < TOTAL_COLORS) blur[index] = inValue;
-  else std::cout << "Vision:setBlur: could not set (invalid index)" << std::endl;
+void Vision::setBlur(int convertType, int index, int inValue) {
+  if (index >= 0 && index < TOTAL_COLORS && (convertType == HSV || convertType == CIELAB)) blur[convertType][index] = inValue;
+  else std::cout << "Vision:setBlur: could not set (invalid index or convert type)" << std::endl;
 }
 
-void Vision::setAmin(int index, int inValue) {
-  if (index >= 0 && index < TOTAL_COLORS) areaMin[index] = inValue;
-  else std::cout << "Vision:setAmin: could not set (invalid index)" << std::endl;
+void Vision::setAmin(int convertType, int index, int inValue) {
+  if (index >= 0 && index < TOTAL_COLORS && (convertType == HSV || convertType == CIELAB)) areaMin[convertType][index] = inValue;
+  else std::cout << "Vision:setAmin: could not set (invalid index or convert type)" << std::endl;
+}
+
+void Vision::setConvertType(int type) {
+	if (type == HSV || type == CIELAB) convertType = type;
+	else std::cout << "Vision:setConvertType: could not set type (invalid type)" << std::endl;
 }
 
 void Vision::setFrameSize(int inWidth, int inHeight) {
@@ -630,24 +684,17 @@ cv::Point* Vision::getAllAdvRobots() {
 }
 
 
-Vision::Vision(int w, int h) : width(w), height(h), bOnAir(false)
+Vision::Vision(int w, int h) : width(w), height(h), bOnAir(false), convertType(HSV),
+robot_list(3), threshold_frame(TOTAL_COLORS), tags(TOTAL_COLORS)
 {
-  // Variables Init
-  cv::Mat mat;
-  std::vector<Tag> tagVec;
-  Robot robot;
 
-  for (int i = 0; i < TOTAL_COLORS; i++) {
-    threshold_frame.push_back(mat);
-    tags.push_back(tagVec);
-  }
-
-  robot_list.push_back(robot);
-  robot_list.push_back(robot);
-  robot_list.push_back(robot);
 }
 
 Vision::~Vision()
 {
 
 }
+
+
+
+

--- a/cc/vision/vision.hpp
+++ b/cc/vision/vision.hpp
@@ -23,13 +23,13 @@ private:
   // Constants
   static const int MAIN = 0;
   static const int GREEN = 1;
-  // static const int PINK = 2;
   static const int BALL = 2;
   static const int ADV = 3;
   static const int MAX_ADV = 3;
   static const int TOTAL_COLORS = 4;
   static const int MIN = 0;
   static const int MAX = 1;
+
 
   // Frames
   cv::Mat in_frame, hsv_frame;
@@ -46,14 +46,18 @@ private:
   // TAGS
   std::vector<std::vector<Tag>> tags;
 
-  // HSV Calibration Parameters
-  int hue[5][2];
-  int saturation[5][2];
-  int value[5][2];
-  int dilate[5];
-  int erode[5];
-  int blur[5];
-  int areaMin[5];
+  // HSV/CIELAB Calibration Parameters
+  int hue[4][2];
+  int saturation[4][2];
+  int value[4][2];
+		int cieL[4][2];
+		int cieA[4][2];
+		int cieB[4][2];
+  int dilate[2][4];
+  int erode[2][4];
+  int blur[2][4];
+  int areaMin[2][4];
+		int convertType;
 
   // image size
   int width;
@@ -80,13 +84,17 @@ private:
   int inSphere(Robot * robot, std::vector<Tag> * tempTags, cv::Point secondary);
 
 public:
+		// Public constants
+		static const int HSV = 0;
+		static const int CIELAB = 1;
+
   Vision(int w, int h);
   ~Vision();
 
   void run(cv::Mat raw_frame);
   void runGMM(std::vector<cv::Mat> thresholds, std::vector<VisionROI> *windowsList);
   void recordVideo(cv::Mat frame);
-  void setCalibParams(int H[5][2], int S[5][2], int V[5][2], int Amin[5], int E[5], int D[5], int B[5]);
+  void setCalibParams(int type, int H[5][2], int S[5][2], int V[5][2], int Amin[5], int E[5], int D[5], int B[5]);
   double calcDistance(cv::Point p1, cv::Point p2);
 
   void startNewVideo(std::string videoName);
@@ -102,7 +110,7 @@ public:
   cv::Point getRobotPos(int index);
   cv::Point getAdvRobot(int index);
   cv::Point* getAllAdvRobots();
-  cv::Mat getSplitFrame();
+		cv::Mat getSplitFrame();
 
   int getRobotListSize();
   int getAdvListSize();
@@ -112,10 +120,14 @@ public:
   int getHue(int index0, int index1);
   int getSaturation(int index0, int index1);
   int getValue(int index0, int index1);
-  int getErode(int index);
-  int getDilate(int index);
-  int getBlur(int index);
-  int getAmin(int index);
+		int getCIE_L(int index0, int index1);
+		int getCIE_A(int index0, int index1);
+		int getCIE_B(int index0, int index1);
+		int getConvertType();
+  int getErode(int convertType, int index);
+  int getDilate(int convertType, int index);
+  int getBlur(int convertType, int index);
+  int getAmin(int convertType, int index);
 
   void setFrameSize(int inWidth, int inHeight);
   int getFrameHeight();
@@ -124,10 +136,14 @@ public:
   void setHue(int index0, int index1, int inValue);
   void setSaturation(int index0, int index1, int inValue);
   void setValue(int index0, int index1, int inValue);
-  void setErode(int index, int inValue);
-  void setDilate(int index, int inValue);
-  void setBlur(int index, int inValue);
-  void setAmin(int index, int inValue);
+		void setCIE_L(int index0, int index1, int inValue);
+		void setCIE_A(int index0, int index1, int inValue);
+		void setCIE_B(int index0, int index1, int inValue);
+		void setConvertType(int type);
+  void setErode(int convertType, int index, int inValue);
+  void setDilate(int convertType, int index, int inValue);
+  void setBlur(int convertType, int index, int inValue);
+  void setAmin(int convertType, int index, int inValue);
 
 
 };

--- a/cc/vision/visionGUI.cpp
+++ b/cc/vision/visionGUI.cpp
@@ -599,7 +599,7 @@ void VisionGUI::__create_frm_hsv() {
   vbox->set_halign(Gtk::ALIGN_CENTER);
   vbox->set_valign(Gtk::ALIGN_CENTER);
 
-  fr_HSV.set_label("HSV Calibration");
+  fr_HSV.set_label("HSV/CIELAB Calibration");
 
   grid->set_border_width(5);
   grid->set_column_spacing(15);
@@ -619,6 +619,11 @@ void VisionGUI::__create_frm_hsv() {
   bt_switchMainAdv.set_label("Main <-> Adv");
   grid->attach(bt_switchMainAdv, 6, 0, 1, 1);
 
+	cb_convertType.append("HSV");
+	cb_convertType.append("CIELAB");
+	cb_convertType.set_active(0);
+	grid->attach(cb_convertType, 7, 0, 1, 1);
+
   grid = new Gtk::Grid();
   grid->set_border_width(5);
   grid->set_column_spacing(15);
@@ -626,9 +631,9 @@ void VisionGUI::__create_frm_hsv() {
   grid->set_column_homogeneous(true);
   vbox->pack_start(*grid, false, true, 5);
 
-  label = new Gtk::Label("Hmin:");
-  label->set_alignment(1.0, 1.0);
-  grid->attach(*label, 0, 0, 1, 1);
+	lb_Hmin.set_text("Hmin");
+  lb_Hmin.set_alignment(1.0, 1.0);
+  grid->attach(lb_Hmin, 0, 0, 1, 1);
 
   HScale_Hmin.set_digits(0);
   HScale_Hmin.set_increments(1,1);
@@ -637,20 +642,20 @@ void VisionGUI::__create_frm_hsv() {
   HScale_Hmin.set_draw_value();
   grid->attach(HScale_Hmin, 1, 0, 2, 1);
 
-  label = new Gtk::Label("Hmax:");
-  label->set_alignment(1.0, 1.0);
-  grid->attach(*label, 3, 0, 1, 1);
+	lb_Hmax.set_text("Hmax");
+	lb_Hmax.set_alignment(1.0, 1.0);
+  grid->attach(lb_Hmax, 3, 0, 1, 1);
 
   HScale_Hmax.set_digits(0);
   HScale_Hmax.set_increments(1,1);
-  HScale_Hmax.set_range(0,180);
+  HScale_Hmax.set_range(0,255);
   HScale_Hmax.set_value_pos(Gtk::POS_TOP);
   HScale_Hmax.set_draw_value();
   grid->attach(HScale_Hmax, 4, 0, 2, 1);
 
-  label = new Gtk::Label("Smin:");
-  label->set_alignment(1.0, 1.0);
-   grid->attach(*label, 0, 1, 1, 1);
+	lb_Smin.set_text("Smin");
+	lb_Smin.set_alignment(1.0, 1.0);
+   grid->attach(lb_Smin, 0, 1, 1, 1);
 
   HScale_Smin.set_digits(0);
   HScale_Smin.set_increments(1,1);
@@ -659,9 +664,9 @@ void VisionGUI::__create_frm_hsv() {
   HScale_Smin.set_draw_value();
   grid->attach(HScale_Smin, 1, 1, 2, 1);
 
-  label = new Gtk::Label("Smax:");
-  label->set_alignment(1.0, 1.0);
-  grid->attach(*label, 3, 1, 1, 1);
+	lb_Smax.set_text("Smax");
+  lb_Smax.set_alignment(1.0, 1.0);
+  grid->attach(lb_Smax, 3, 1, 1, 1);
 
   HScale_Smax.set_digits(0);
   HScale_Smax.set_increments(1,1);
@@ -671,9 +676,9 @@ void VisionGUI::__create_frm_hsv() {
 
   grid->attach(HScale_Smax,4, 1, 2, 1);
 
-  label = new Gtk::Label("Vmin:");
-  label->set_alignment(1.0, 1.0);
-  grid->attach(*label, 0, 2, 1, 1);
+	lb_Vmin.set_text("Vmin");
+  lb_Vmin.set_alignment(1.0, 1.0);
+  grid->attach(lb_Vmin, 0, 2, 1, 1);
 
   HScale_Vmin.set_digits(0);
   HScale_Vmin.set_increments(1,1);
@@ -682,9 +687,9 @@ void VisionGUI::__create_frm_hsv() {
   HScale_Vmin.set_draw_value();
   grid->attach(HScale_Vmin, 1, 2, 2, 1);
 
-  label = new Gtk::Label("Vmax:");
-  label->set_alignment(1.0, 1.0);
-  grid->attach(*label, 3, 2, 1, 1);
+	lb_Vmax.set_text("Vmax");
+  lb_Vmax.set_alignment(1.0, 1.0);
+  grid->attach(lb_Vmax, 3, 2, 1, 1);
 
   HScale_Vmax.set_digits(0);
   HScale_Vmax.set_increments(1,1);
@@ -741,6 +746,7 @@ void VisionGUI::__create_frm_hsv() {
 
   bt_HSV_calib.set_state(Gtk::STATE_INSENSITIVE);
   bt_switchMainAdv.set_state(Gtk::STATE_INSENSITIVE);
+	cb_convertType.set_state(Gtk::STATE_INSENSITIVE);
   HScale_Hmin.set_state(Gtk::STATE_INSENSITIVE);
   HScale_Smin.set_state(Gtk::STATE_INSENSITIVE);
   HScale_Vmin.set_state(Gtk::STATE_INSENSITIVE);
@@ -758,6 +764,7 @@ void VisionGUI::__create_frm_hsv() {
   bt_HSV_right.signal_clicked().connect(sigc::mem_fun(*this, &VisionGUI::__event_bt_right_HSV_calib_clicked));
   bt_HSV_left.signal_clicked().connect(sigc::mem_fun(*this, &VisionGUI::__event_bt_left_HSV_calib_clicked));
   bt_switchMainAdv.signal_clicked().connect(sigc::mem_fun(*this, &VisionGUI::__event_bt_switchMainAdv_clicked));
+	cb_convertType.signal_changed().connect(sigc::mem_fun(*this, &VisionGUI::__event_cb_convertType_changed));
   HScale_Hmin.signal_value_changed().connect(sigc::mem_fun(*this, &VisionGUI::HScale_Hmin_value_changed));
   HScale_Hmax.signal_value_changed().connect(sigc::mem_fun(*this, &VisionGUI::HScale_Hmax_value_changed));
   HScale_Smin.signal_value_changed().connect(sigc::mem_fun(*this, &VisionGUI::HScale_Smin_value_changed));
@@ -770,19 +777,67 @@ void VisionGUI::__create_frm_hsv() {
   HScale_Amin.signal_value_changed().connect(sigc::mem_fun(*this, &VisionGUI::HScale_Amin_value_changed));
 }
 
+void VisionGUI::__event_cb_convertType_changed() {
+  int type = cb_convertType.get_active_row_number();
+	vision->setConvertType(type);
+
+  HScale_Hmin.set_value(vision->getCIE_L(Img_id, 0));
+  HScale_Hmax.set_value(vision->getCIE_L(Img_id, 1));
+  HScale_Smin.set_value(vision->getCIE_A(Img_id, 0));
+  HScale_Smax.set_value(vision->getCIE_A(Img_id, 1));
+  HScale_Vmin.set_value(vision->getCIE_B(Img_id, 0));
+  HScale_Vmax.set_value(vision->getCIE_B(Img_id, 1));
+  HScale_Erode.set_value(vision->getErode(type, Img_id));
+  HScale_Dilate.set_value(vision->getDilate(type, Img_id));
+  HScale_Blur.set_value(vision->getBlur(type, Img_id));
+  HScale_Amin.set_value(vision->getAmin(type, Img_id));
+
+	if (type == vision->CIELAB) {
+		lb_Hmin.set_text("Lmin");
+		lb_Hmax.set_text("Lmax");
+		lb_Smin.set_text("Green");
+		lb_Smax.set_text("Red");
+		lb_Vmin.set_text("Blue");
+		lb_Vmax.set_text("Yellow");
+	} else {
+		lb_Hmin.set_text("Hmin");
+		lb_Hmax.set_text("Hmax");
+		lb_Smin.set_text("Smin");
+		lb_Smax.set_text("Smax");
+		lb_Vmin.set_text("Vmin");
+		lb_Vmax.set_text("Vmax");
+	}
+
+
+}
+
 void VisionGUI::__event_bt_switchMainAdv_clicked() {
   vision->switchMainWithAdv();
-  HScale_Hmin.set_value(vision->getHue(Img_id, 0));
-  HScale_Hmax.set_value(vision->getHue(Img_id, 1));
-  HScale_Smin.set_value(vision->getSaturation(Img_id, 0));
-  HScale_Smax.set_value(vision->getSaturation(Img_id, 1));
-  HScale_Vmin.set_value(vision->getValue(Img_id, 0));
-  HScale_Vmax.set_value(vision->getValue(Img_id, 1));
-  HScale_Amin.set_value(vision->getAmin(Img_id));
-  HScale_Blur.set_value(vision->getBlur(Img_id));
-  HScale_Erode.set_value(vision->getErode(Img_id));
-  HScale_Dilate.set_value(vision->getDilate(Img_id));
-}
+	if (vision->getConvertType()) { // CIELAB
+		HScale_Hmin.set_value(vision->getCIE_L(Img_id, 0));
+		HScale_Hmax.set_value(vision->getCIE_L(Img_id, 1));
+		HScale_Smin.set_value(vision->getCIE_A(Img_id, 0));
+		HScale_Smax.set_value(vision->getCIE_A(Img_id, 1));
+		HScale_Vmin.set_value(vision->getCIE_B(Img_id, 0));
+		HScale_Vmax.set_value(vision->getCIE_B(Img_id, 1));
+		HScale_Amin.set_value(vision->getAmin(vision->CIELAB, Img_id));
+		HScale_Blur.set_value(vision->getBlur(vision->CIELAB, Img_id));
+		HScale_Erode.set_value(vision->getErode(vision->CIELAB, Img_id));
+		HScale_Dilate.set_value(vision->getDilate(vision->CIELAB, Img_id));
+	} else { // HSV
+		HScale_Hmin.set_value(vision->getHue(Img_id, 0));
+		HScale_Hmax.set_value(vision->getHue(Img_id, 1));
+		HScale_Smin.set_value(vision->getSaturation(Img_id, 0));
+		HScale_Smax.set_value(vision->getSaturation(Img_id, 1));
+		HScale_Vmin.set_value(vision->getValue(Img_id, 0));
+		HScale_Vmax.set_value(vision->getValue(Img_id, 1));
+		HScale_Amin.set_value(vision->getAmin(vision->HSV, Img_id));
+		HScale_Blur.set_value(vision->getBlur(vision->HSV, Img_id));
+		HScale_Erode.set_value(vision->getErode(vision->HSV, Img_id));
+		HScale_Dilate.set_value(vision->getDilate(vision->HSV, Img_id));
+	}
+	}
+
 
 void VisionGUI::HScale_Hmin_value_changed() {
   vision->setHue(Img_id, 0, HScale_Hmin.get_value());
@@ -809,15 +864,15 @@ void VisionGUI::HScale_Vmax_value_changed() {
 }
 
 void VisionGUI::HScale_Amin_value_changed() {
-  vision->setAmin(Img_id, HScale_Amin.get_value());
+  vision->setAmin(vision->getConvertType(), Img_id, HScale_Amin.get_value());
 }
 
 void VisionGUI::HScale_Dilate_value_changed() {
 
  if(HScale_Dilate.get_value()<0){
-   vision->setDilate(Img_id, 0);
+   vision->setDilate(vision->getConvertType(), Img_id, 0);
  }else{
-   vision->setDilate(Img_id, HScale_Dilate.get_value());
+   vision->setDilate(vision->getConvertType(), Img_id, HScale_Dilate.get_value());
  }
   //std::cout<<"=================================================="<<D[Img_id]<<std::endl;
 
@@ -827,9 +882,9 @@ void VisionGUI::HScale_Erode_value_changed() {
 
 
  if(HScale_Erode.get_value()<0){
-   vision->setErode(Img_id, 0);
+   vision->setErode(vision->getConvertType(), Img_id, 0);
  }else{
-   vision->setErode(Img_id, HScale_Erode.get_value());
+   vision->setErode(vision->getConvertType(), Img_id, HScale_Erode.get_value());
  }
   //std::cout<<"=================================================="<<E[Img_id]<<std::endl;
 
@@ -838,13 +893,13 @@ void VisionGUI::HScale_Erode_value_changed() {
 void VisionGUI::HScale_Blur_value_changed() {
 
  if(HScale_Blur.get_value()<3){
-   vision->setBlur(Img_id, 3);
+   vision->setBlur(vision->getConvertType(), Img_id, 3);
  }
  else if((int) HScale_Blur.get_value() % 2 == 0){
-   vision->setBlur(Img_id, (int) HScale_Blur.get_value()+1);
+   vision->setBlur(vision->getConvertType(), Img_id, (int) HScale_Blur.get_value()+1);
  }
  else{
-   vision->setBlur(Img_id, (int)HScale_Blur.get_value());
+   vision->setBlur(vision->getConvertType(), Img_id, (int)HScale_Blur.get_value());
  }
   //std::cout<<"====Blur: "<<B[Img_id]<<" id color: "<<Img_id<<std::endl;
 
@@ -868,6 +923,7 @@ void VisionGUI::__event_bt_HSV_calib_pressed() {
     bt_HSV_right.set_state(Gtk::STATE_INSENSITIVE);
     bt_HSV_left.set_state(Gtk::STATE_INSENSITIVE);
     bt_switchMainAdv.set_state(Gtk::STATE_INSENSITIVE);
+	  cb_convertType.set_state(Gtk::STATE_INSENSITIVE);
   } else {
     HSV_calib_event_flag=true;
     HScale_Hmin.set_state(Gtk::STATE_NORMAL);
@@ -883,6 +939,7 @@ void VisionGUI::__event_bt_HSV_calib_pressed() {
     bt_HSV_right.set_state(Gtk::STATE_NORMAL);
     bt_HSV_left.set_state(Gtk::STATE_NORMAL);
     bt_switchMainAdv.set_state(Gtk::STATE_NORMAL);
+	  cb_convertType.set_state(Gtk::STATE_NORMAL);
   }
 }
 
@@ -931,23 +988,38 @@ void VisionGUI::selectFrame(int sector) {
 
 void VisionGUI::__event_bt_right_HSV_calib_clicked() {
 
+	int type = vision->getConvertType();
+
   Img_id=Img_id+1;
 
   if(Img_id>3) Img_id = 0;
-  HScale_Hmin.set_value(vision->getHue(Img_id, 0));
-  HScale_Hmax.set_value(vision->getHue(Img_id, 1));
 
-  HScale_Smin.set_value(vision->getSaturation(Img_id, 0));
-  HScale_Smax.set_value(vision->getSaturation(Img_id, 1));
+	if (type == vision->HSV) {
+		HScale_Hmin.set_value(vision->getHue(Img_id, 0));
+		HScale_Hmax.set_value(vision->getHue(Img_id, 1));
 
-  HScale_Vmin.set_value(vision->getValue(Img_id, 0));
-  HScale_Vmax.set_value(vision->getValue(Img_id, 1));
+		HScale_Smin.set_value(vision->getSaturation(Img_id, 0));
+		HScale_Smax.set_value(vision->getSaturation(Img_id, 1));
 
-  HScale_Dilate.set_value(vision->getDilate(Img_id));
-  HScale_Erode.set_value(vision->getErode(Img_id));
+		HScale_Vmin.set_value(vision->getValue(Img_id, 0));
+		HScale_Vmax.set_value(vision->getValue(Img_id, 1));
+	} else { // CIELAB
+		HScale_Hmin.set_value(vision->getCIE_L(Img_id, 0));
+		HScale_Hmax.set_value(vision->getCIE_L(Img_id, 1));
 
-  HScale_Blur.set_value(vision->getBlur(Img_id));
-  HScale_Amin.set_value(vision->getAmin(Img_id));
+		HScale_Smin.set_value(vision->getCIE_A(Img_id, 0));
+		HScale_Smax.set_value(vision->getCIE_A(Img_id, 1));
+
+		HScale_Vmin.set_value(vision->getCIE_B(Img_id, 0));
+		HScale_Vmax.set_value(vision->getCIE_B(Img_id, 1));
+	}
+
+  HScale_Dilate.set_value(vision->getDilate(vision->getConvertType(), Img_id));
+  HScale_Erode.set_value(vision->getErode(vision->getConvertType(), Img_id));
+
+  HScale_Blur.set_value(vision->getBlur(vision->getConvertType(), Img_id));
+  HScale_Amin.set_value(vision->getAmin(vision->getConvertType(), Img_id));
+
   switch(Img_id) {
   case 0:
       HSV_label.set_text("Main");
@@ -955,9 +1027,6 @@ void VisionGUI::__event_bt_right_HSV_calib_clicked() {
   case 1:
       HSV_label.set_text("Green");
       break;
-  // case 2:
-  //     HSV_label.set_text("Pink");
-  //     break;
   case 2:
       HSV_label.set_text("Ball");
       break;
@@ -969,22 +1038,39 @@ void VisionGUI::__event_bt_right_HSV_calib_clicked() {
 
 void VisionGUI::__event_bt_left_HSV_calib_clicked() {
 
+	int type = vision->getConvertType();
+
   Img_id=Img_id-1;
+
   if(Img_id<0) Img_id = 3;
-  HScale_Hmin.set_value(vision->getHue(Img_id, 0));
-  HScale_Hmax.set_value(vision->getHue(Img_id, 1));
 
-  HScale_Smin.set_value(vision->getSaturation(Img_id, 0));
-  HScale_Smax.set_value(vision->getSaturation(Img_id, 1));
+	if (type == vision->HSV) {
+		HScale_Hmin.set_value(vision->getHue(Img_id, 0));
+		HScale_Hmax.set_value(vision->getHue(Img_id, 1));
 
-  HScale_Vmin.set_value(vision->getValue(Img_id, 0));
-  HScale_Vmax.set_value(vision->getValue(Img_id, 1));
+		HScale_Smin.set_value(vision->getSaturation(Img_id, 0));
+		HScale_Smax.set_value(vision->getSaturation(Img_id, 1));
 
-  HScale_Dilate.set_value(vision->getDilate(Img_id));
-  HScale_Erode.set_value(vision->getErode(Img_id));
+		HScale_Vmin.set_value(vision->getValue(Img_id, 0));
+		HScale_Vmax.set_value(vision->getValue(Img_id, 1));
+	} else { // CIELAB
+		HScale_Hmin.set_value(vision->getCIE_L(Img_id, 0));
+		HScale_Hmax.set_value(vision->getCIE_L(Img_id, 1));
 
-  HScale_Blur.set_value(vision->getBlur(Img_id));
-  HScale_Amin.set_value(vision->getAmin(Img_id));
+		HScale_Smin.set_value(vision->getCIE_A(Img_id, 0));
+		HScale_Smax.set_value(vision->getCIE_A(Img_id, 1));
+
+		HScale_Vmin.set_value(vision->getCIE_B(Img_id, 0));
+		HScale_Vmax.set_value(vision->getCIE_B(Img_id, 1));
+	}
+
+
+  HScale_Dilate.set_value(vision->getDilate(type, Img_id));
+  HScale_Erode.set_value(vision->getErode(type, Img_id));
+
+  HScale_Blur.set_value(vision->getBlur(type, Img_id));
+  HScale_Amin.set_value(vision->getAmin(type, Img_id));
+
   switch(Img_id) {
   case 0:
       HSV_label.set_text("Main");
@@ -992,9 +1078,6 @@ void VisionGUI::__event_bt_left_HSV_calib_clicked() {
   case 1:
       HSV_label.set_text("Green");
       break;
-  // case 2:
-  //     HSV_label.set_text("Pink");
-  //     break;
   case 2:
       HSV_label.set_text("Ball");
       break;
@@ -1034,16 +1117,18 @@ void VisionGUI::decrementSamples() {
 void VisionGUI::init_calib_params()
 {
   // Inicializar variáveis de calibração
-  int H[5][2] = { {0,180}, {0,180}, {0,180}, {0,180}, {0,180} };
-  int S[5][2] = { {0, 255}, {0, 255}, {0, 255}, {0, 255}, {0, 255} };
-  int V[5][2] = { {0, 255}, {0, 255}, {0, 255}, {0, 255}, {0, 255} };
-  int B[5] {3, 3, 3, 3, 3};
-  int D[5] = {0, 0, 0, 0, 0};
-  int E[5] = {0, 0, 0, 0, 0};
-  int Amin[5] = {150, 90, 90, 115, 50};
+  int H[4][2] = { {0,180}, {0,180}, {0,180}, {0,180} };
+  int S[4][2] = { {0, 255}, {0, 255}, {0, 255}, {0, 255} };
+  int V[4][2] = { {0, 255}, {0, 255}, {0, 255}, {0, 255} };
+	int LAB[4][2] = { {0,255}, {0,255}, {0,255}, {0,255} };
+  int B[4] {3, 3, 3, 3};
+  int D[4] = {0, 0, 0, 0};
+  int E[4] = {0, 0, 0, 0};
+  int Amin[4] = {150, 90, 90, 115};
 
   // Configurar os valores iniciais de calibração
-  vision->setCalibParams(H, S, V, Amin, E, D, B);
+  vision->setCalibParams(vision->HSV, H, S, V, Amin, E, D, B);
+	vision->setCalibParams(vision->CIELAB, LAB, S, V, Amin, E, D, B);
 
   // Corrigir os valores mostrados na interface
   HScale_Hmax.set_value(H[0][1]);

--- a/cc/vision/visionGUI.hpp
+++ b/cc/vision/visionGUI.hpp
@@ -33,6 +33,8 @@ public:
 
   Gtk::Scale HScale_Amin;
 
+		Gtk::Label lb_Hmin, lb_Hmax, lb_Smin, lb_Smax, lb_Vmin, lb_Vmax;
+
   Gtk::ToggleButton bt_record_video;
   Gtk::Button bt_save_picture;
   Gtk::Entry en_video_name, en_picture_name;
@@ -87,6 +89,7 @@ private:
   Gtk::Button bt_HSV_left;
   Gtk::Button bt_HSV_right;
   Gtk::Button bt_switchMainAdv;
+        Gtk::ComboBoxText cb_convertType;
 
   // Frame GMM
   Gtk::Frame fr_GMM;
@@ -166,6 +169,7 @@ private:
 
   // void __event_auto_save();
 
+		void __event_cb_convertType_changed();
 };
 
 #endif /* VISIONGUI_HPP_ */

--- a/cc/vision/visionGUI.hpp
+++ b/cc/vision/visionGUI.hpp
@@ -169,6 +169,7 @@ private:
 
   // void __event_auto_save();
 
+    public:
 		void __event_cb_convertType_changed();
 };
 

--- a/pack-capture-gui/capture-gui/V4LInterface-events.cpp
+++ b/pack-capture-gui/capture-gui/V4LInterface-events.cpp
@@ -650,19 +650,7 @@ namespace capture {
     }
 
     void V4LInterface::update_interface_camera() {
-        visionGUI.HScale_Hmin.set_value(visionGUI.vision->getHue(visionGUI.Img_id, 0));
-        visionGUI.HScale_Hmax.set_value(visionGUI.vision->getHue(visionGUI.Img_id, 1));
-
-        visionGUI.HScale_Smin.set_value(visionGUI.vision->getSaturation(visionGUI.Img_id, 0));
-        visionGUI.HScale_Smax.set_value(visionGUI.vision->getSaturation(visionGUI.Img_id, 1));
-
-        visionGUI.HScale_Vmin.set_value(visionGUI.vision->getValue(visionGUI.Img_id, 0));
-        visionGUI.HScale_Vmax.set_value(visionGUI.vision->getValue(visionGUI.Img_id, 1));
-
-        visionGUI.HScale_Dilate.set_value(visionGUI.vision->getDilate(visionGUI.vision->getConvertType(), visionGUI.Img_id));
-        visionGUI.HScale_Erode.set_value(visionGUI.vision->getErode(visionGUI.vision->getConvertType(), visionGUI.Img_id));
-        visionGUI.HScale_Blur.set_value(visionGUI.vision->getBlur(visionGUI.vision->getConvertType(), visionGUI.Img_id));
-        visionGUI.HScale_Amin.set_value(visionGUI.vision->getAmin(visionGUI.vision->getConvertType(), visionGUI.Img_id));
+        visionGUI.__event_cb_convertType_changed();
 
         if(warped) {
             bt_warp.set_state(Gtk::STATE_INSENSITIVE);

--- a/pack-capture-gui/capture-gui/V4LInterface-events.cpp
+++ b/pack-capture-gui/capture-gui/V4LInterface-events.cpp
@@ -659,10 +659,10 @@ namespace capture {
         visionGUI.HScale_Vmin.set_value(visionGUI.vision->getValue(visionGUI.Img_id, 0));
         visionGUI.HScale_Vmax.set_value(visionGUI.vision->getValue(visionGUI.Img_id, 1));
 
-        visionGUI.HScale_Dilate.set_value(visionGUI.vision->getDilate(visionGUI.Img_id));
-        visionGUI.HScale_Erode.set_value(visionGUI.vision->getErode(visionGUI.Img_id));
-        visionGUI.HScale_Blur.set_value(visionGUI.vision->getBlur(visionGUI.Img_id));
-        visionGUI.HScale_Amin.set_value(visionGUI.vision->getAmin(visionGUI.Img_id));
+        visionGUI.HScale_Dilate.set_value(visionGUI.vision->getDilate(visionGUI.vision->getConvertType(), visionGUI.Img_id));
+        visionGUI.HScale_Erode.set_value(visionGUI.vision->getErode(visionGUI.vision->getConvertType(), visionGUI.Img_id));
+        visionGUI.HScale_Blur.set_value(visionGUI.vision->getBlur(visionGUI.vision->getConvertType(), visionGUI.Img_id));
+        visionGUI.HScale_Amin.set_value(visionGUI.vision->getAmin(visionGUI.vision->getConvertType(), visionGUI.Img_id));
 
         if(warped) {
             bt_warp.set_state(Gtk::STATE_INSENSITIVE);


### PR DESCRIPTION
Essa adição é para comparar o espaço de cores CIELAB com o HSV para a segmentação por threshold e ver qual é mellhor.
- Adição de uma combo box para escolher entre HSV e CIELAB
- CIELAB integrado no sistema de SAVE/LOAD
- Pequenas correções no código da Visão.