### PR TITLE
Permite ativar ou desativar ACKs no xbee

### DIFF
--- a/cc/Messenger.cpp
+++ b/cc/Messenger.cpp
@@ -110,7 +110,12 @@ string Messenger::rounded_str(double num) {
 	return ss.str();
 }
 
-ack_count Messenger::get_ack_count(char id){
+void Messenger::set_ack_enabled(bool enable) {
+	if(!xbee) return;
+	xbee->set_ack_enabled(enable);
+}
+
+ack_count Messenger::get_ack_count(char id) {
 	if(!xbee) return {-1,-1,-1};
 	else return xbee->get_ack_count(id);
 }

--- a/cc/Messenger.h
+++ b/cc/Messenger.h
@@ -28,6 +28,7 @@ class Messenger {
 		void send_msg(char id, std::string msg);
 		void send_old_format(std::string cmd);
 		double get_battery(char id);
+		void set_ack_enabled(bool enable);
 		ack_count get_ack_count(char id);
 		void reset_lost_acks();
 		void start_xbee(const std::string& port, int baud = 115200);

--- a/cc/Xbee.cpp
+++ b/cc/Xbee.cpp
@@ -1,7 +1,9 @@
 #include <iostream>
 #include "Xbee.h"
 
-using namespace std;
+using std::string;
+using std::pair;
+using std::vector;
 
 Xbee::Xbee(const string &port, int baud) {
 	xbee_err ret;
@@ -9,7 +11,7 @@ Xbee::Xbee(const string &port, int baud) {
 	if ((ret = xbee_setup(&xbee, "xbee1", port.c_str(), baud)) != XBEE_ENONE) {
 		printf("Xbee setup error: %d (%s)\n", ret, xbee_errorToStr(ret));
 	} else {
-		cout << "Xbee connected on " << port << endl;
+		std::cout << "Xbee connected on " << port << std::endl;
 	}
 }
 
@@ -35,6 +37,7 @@ void Xbee::add_robot(char id, uint16_t addr) {
 		printf("Xbee connection error: %d (%s)\n", ret, xbee_errorToStr(ret));
 		return;
 	}
+	set_ack_enabled(id, false);
 
 	robots[id] = {id,addr,con,{0,0,0}};
 }
@@ -59,7 +62,24 @@ vector<message> Xbee::get_messages() {
 	return msgs;
 }
 
-vector<message> Xbee::send_get_answer_all(const std::string &message) {
+string Xbee::send_get_answer(char id, const string &message) {
+	if(robots.count(id) == 0) return "erro";
+	struct xbee_pkt *pkt;
+	uint8_t ack;
+	bool ack_enabled = is_ack_enabled(id);
+
+	set_ack_enabled(id, true);
+	xbee_conTx(robots[id].con, &ack, message.c_str());
+	set_ack_enabled(id, ack_enabled);
+
+	update_ack(id, ack);
+	if (ack == 0 && xbee_conRxWait(robots[id].con, &pkt, nullptr) == XBEE_ENONE && pkt->dataLen > 0)
+		return get_string(pkt);
+	else
+		return "erro";
+}
+
+vector<message> Xbee::send_get_answer(const std::string &message) {
 	vector<struct message> msgs;
 	for(auto& r : robots){
 		string ret = send_get_answer(r.second.id,message);
@@ -68,20 +88,33 @@ vector<message> Xbee::send_get_answer_all(const std::string &message) {
 	return msgs;
 }
 
-string Xbee::send_get_answer(char id, const string &message) {
-	if(robots.count(id) == 0) return "erro";
+void Xbee::set_ack_enabled(char id, bool enable) {
+	if(robots.count(id) == 0) return;
+	struct xbee_con* con = robots[id].con;
+	struct xbee_conSettings settings{};
 
-	struct xbee_pkt *pkt;
-	uint8_t ack;
-	xbee_conTx(robots[id].con, &ack, message.c_str());
-	update_ack(id, ack);
-	if (ack == 0 && xbee_conRxWait(robots[id].con, &pkt, nullptr) == XBEE_ENONE && pkt->dataLen > 0)
-		return get_string(pkt);
-	else
-		return "erro";
+	xbee_conSettings(con, nullptr, &settings);
+	settings.disableAck = (uint8_t) !enable;
+	xbee_conSettings(con, &settings, nullptr);
+	if(!enable) robots[id].acks = {0,0,0};
+}
+
+void Xbee::set_ack_enabled(bool enable) {
+	for(auto& robot : robots) {
+		set_ack_enabled(robot.second.id, enable);
+	}
+}
+
+bool Xbee::is_ack_enabled(char id) {
+	if(robots.count(id) == 0) return false;
+	struct xbee_conSettings settings{};
+
+	xbee_conSettings(robots[id].con, nullptr, &settings);
+	return !settings.disableAck;
 }
 
 void Xbee::update_ack(char id, int ack) {
+	if(!is_ack_enabled(id)) return;
 	ack_count& acks = robots[id].acks;
 	if(ack != 0) acks.lost++;
 	acks.total++;

--- a/cc/Xbee.h
+++ b/cc/Xbee.h
@@ -30,6 +30,8 @@ class Xbee {
 	private:
 		struct xbee *xbee;
 		std::unordered_map<char, robot_xbee> robots;
+		std::string get_string(xbee_pkt *pkt);
+		void update_ack(char id, int ack);
 
 	public:
 		Xbee(const std::string &port, int baud);
@@ -37,12 +39,13 @@ class Xbee {
 		void add_robot(char id, uint16_t addr);
 		int send(char id, const std::string &message);
 		std::string send_get_answer(char id, const std::string &message);
-		std::vector<message> send_get_answer_all(const std::string &message);
+		std::vector<message> send_get_answer(const std::string &message);
 		std::vector<message> get_messages();
-		void update_ack(char id, int ack);
 		ack_count get_ack_count(char id);
 		void reset_lost_acks();
-		std::string get_string(xbee_pkt *pkt);
+		void set_ack_enabled(char id, bool enable);
+		void set_ack_enabled(bool enable);
+		bool is_ack_enabled(char id);
 };
 
 

--- a/cc/controlGUI.cpp
+++ b/cc/controlGUI.cpp
@@ -38,6 +38,11 @@ ControlGUI::ControlGUI() {
     Serial_hbox[2].pack_start(bt_send_cmd, false, true, 5);
     send_cmd_box.set_width_chars(25);
     bt_send_cmd.set_label("Send Command");
+
+	ack_enable_label.set_label("Enable ACKs");
+	Serial_hbox[2].pack_start(ack_enable_button, false, true, 5);
+	Serial_hbox[2].pack_start(ack_enable_label, false, true, 0);
+
     Serial_vbox.pack_start(Serial_hbox[2], false, true, 5);
 
     Tbox_V1.set_max_length(6);
@@ -79,6 +84,7 @@ ControlGUI::ControlGUI() {
     configureTestFrame();
 
     _update_cb_serial();
+	update_ack_interface();
     // Conectar os sinais para o acontecimento dos eventos
     button_PID_Test.signal_pressed().connect(sigc::mem_fun(*this, &ControlGUI::_PID_Test));
     bt_Serial_test.signal_clicked().connect(sigc::mem_fun(*this, &ControlGUI::_send_test));
@@ -87,6 +93,7 @@ ControlGUI::ControlGUI() {
     bt_Robot_Status.signal_clicked().connect(sigc::mem_fun(*this, &ControlGUI::_robot_status));
 	bt_reset_ack.signal_clicked().connect(sigc::mem_fun(*this, &ControlGUI::reset_lost_acks));
     bt_send_cmd.signal_clicked().connect(sigc::mem_fun(*this, &ControlGUI::_send_command));
+	ack_enable_button.signal_clicked().connect(sigc::mem_fun(*this, &ControlGUI::update_ack_interface));
 }
 
 void ControlGUI::configureTestFrame() {
@@ -317,6 +324,22 @@ void ControlGUI::_create_status_frame(){
         dropped_frames[i].set_label("Lost ACKs: 0.00%, Total: 0");
         status_grid.attach(dropped_frames[i], 4, i+1, 1, 1);
     }
+}
+
+void ControlGUI::update_ack_interface() {
+	bool is_active = ack_enable_button.get_active();
+	messenger.set_ack_enabled(is_active);
+	if(is_active) {
+		for(Gtk::Label& label : dropped_frames){
+			label.show();
+		}
+		bt_reset_ack.show();
+	} else {
+		for(Gtk::Label& label : dropped_frames){
+			label.hide();
+		}
+		bt_reset_ack.hide();
+	}
 }
 
 void ControlGUI::update_dropped_frames() {

--- a/cc/controlGUI.hpp
+++ b/cc/controlGUI.hpp
@@ -61,6 +61,9 @@ public:
 	Gtk::Entry Tbox_V1;
 	Gtk::Entry Tbox_V2;
 
+		Gtk::CheckButton ack_enable_button;
+		Gtk::Label ack_enable_label;
+
 	Gtk::Grid status_grid;
 	Gtk::Frame status_fm;
 	Gtk::Image status_img[TOTAL_ROBOTS];
@@ -113,11 +116,12 @@ public:
 	// Função para verificar se os valores digitados nos campos
 	// de PID são válidos: apenas números e um único ponto
 	bool checkPIDvalues();
-	
+
 	int get_robot_pos(char id);
     char get_robot_id(int pos);
 		void update_dropped_frames();
 		void reset_lost_acks();
+		void update_ack_interface();
 };
 
 

--- a/cc/main.cpp
+++ b/cc/main.cpp
@@ -34,6 +34,7 @@ int main(int argc, char **argv) {
 
 
     camcap.interface.visionGUI.hideGMM();
+    camcap.control.update_ack_interface();
 
     Gtk::Main::run(window);
 


### PR DESCRIPTION
- Opção Enable ACKs permite ativar ou desativar a confirmação de mensagens enviadas para os robôs, permitindo menores delays ao enviar mensagens
- Interface de taxa de perdas so é exibida se ACKs estiverem habilitados
- Mensagens com espera de resposta (como a da bateria) sempre pedem ACKs, para evitar esperar por robôs desligados